### PR TITLE
Fix #180 managing permissions

### DIFF
--- a/app/bin/app.sh
+++ b/app/bin/app.sh
@@ -4,14 +4,14 @@ SCRIPT_DIR="$(dirname "$0")"
 source "$SCRIPT_DIR/app_base.sh"
 
 # waiting for db
-python3 $manage wait-for-db
+su $uid -g $gid -s /bin/bash -c "python3 $manage wait-for-db"
 
 # run migrations
-python3 $manage migrate --noinput
+su $uid -g $gid -s /bin/bash -c "python3 $manage migrate --noinput"
 
 # timeside setup
-python3 $manage timeside-create-admin-user
-python3 $manage timeside-create-boilerplate
+su $uid -g $gid -s /bin/bash -c "python3 $manage timeside-create-admin-user"
+su $uid -g $gid -s /bin/bash -c "python3 $manage timeside-create-boilerplate"
 
 # if [ $DEBUG = "False" ]; then
 #     python $manage update_index --workers $processes &
@@ -25,13 +25,11 @@ npm install --prefix /srv/app
 # app start
 if [ "$1" = "--runserver" ]
 then
-    python3 $manage runserver 0.0.0.0:8000
+    su $uid -g $gid -s /bin/bash -c "python3 $manage runserver 0.0.0.0:8000"
 else
     # static files auto update
-    python3 $manage collectstatic --noinput
+    su $uid -g $gid -s /bin/bash -c "python3 $manage collectstatic --noinput"
 
-    # fix media access rights
-    find $media -maxdepth 1 -path ${media}import -prune -o -type d -not -user www-data -exec chown www-data:www-data {} \;
 
     # watchmedo shell-command --patterns="*.js;*.css" --recursive \
     #     --command='python '$manage' collectstatic --noinput' $src &

--- a/app/bin/app_base.sh
+++ b/app/bin/app_base.sh
@@ -33,5 +33,16 @@ pip3 install -U youtube-dl
 # Install plugins
 bash /srv/app/bin/setup_plugins.sh
 
+# fix media access rights
+find $media -maxdepth 1 -path ${media}import -prune -o -type d -not -user www-data -exec chown www-data:www-data {} \;
+
+mkdir -p '/var/log/celery/'
+mkdir -p '/var/log/app/'
+
+# fix log access for app and celery
+chown -R $uid:$gid '/var/log/celery/'
+chown -R $uid:$gid '/var/log/app/'
+chown -R $uid:$gid '/srv/static'
+
 # wait for other services
 # bash $app/bin/wait.sh

--- a/app/bin/worker.sh
+++ b/app/bin/worker.sh
@@ -6,10 +6,6 @@ source "$SCRIPT_DIR/app_base.sh"
 if [ $DEBUG = True ]; then
     python3 manage.py timeside-celery-worker --loglevel $loglevel --logfile $worker_logfile --uid $uid --gid $gid
 else
-<<<<<<< HEAD
-    celery -A worker worker --loglevel=$loglevel --logfile=$worker_logfile --uid $uid --gid $gid
-=======
     celery -A worker worker --loglevel=$loglevel --logfile=$worker_logfile --uid=$uid --gid=$gid
->>>>>>> [server] add uid and gid args to celery worker command
 fi
 

--- a/app/bin/worker.sh
+++ b/app/bin/worker.sh
@@ -6,6 +6,10 @@ source "$SCRIPT_DIR/app_base.sh"
 if [ $DEBUG = True ]; then
     python3 manage.py timeside-celery-worker --loglevel $loglevel --logfile $worker_logfile --uid $uid --gid $gid
 else
+<<<<<<< HEAD
     celery -A worker worker --loglevel=$loglevel --logfile=$worker_logfile --uid $uid --gid $gid
+=======
+    celery -A worker worker --loglevel=$loglevel --logfile=$worker_logfile --uid=$uid --gid=$gid
+>>>>>>> [server] add uid and gid args to celery worker command
 fi
 

--- a/timeside/server/management/commands/timeside-celery-worker.py
+++ b/timeside/server/management/commands/timeside-celery-worker.py
@@ -13,12 +13,7 @@ def restart_celery(*args, **kwargs):
     kwargs = kwargs['kwargs']
     kill_worker_cmd = 'pkill -9 celery'
     subprocess.call(shlex.split(kill_worker_cmd))
-<<<<<<< HEAD
-    start_worker_cmd = 'celery -A worker worker --loglevel=%s --logfile=%s --uid=%uid --gid=%gid' %
-        (kwargs['loglevel'], kwargs['logfile'], kwargs['uid'], kwargs['gid'])
-=======
     start_worker_cmd = 'celery -A worker worker --loglevel=%s --logfile=%s --uid=%s --gid=%s' % (kwargs['loglevel'], kwargs['logfile'], kwargs['uid'], kwargs['gid'])
->>>>>>> [server] add uid and gid args to celery worker command
     subprocess.call(shlex.split(start_worker_cmd))
 
 
@@ -35,21 +30,12 @@ class Command(BaseCommand):
 
         parser.add_argument('-u', '--uid',
             dest='uid',
-<<<<<<< HEAD
-            help='define the uid')
-
-        parser.add_argument('-g', '--gid',
-            dest='gid',
-            help='define the gid')
-
-=======
             help='define worker uid')
 
         parser.add_argument('-g', '--gid',
             dest='gid',
             help='define worker gid')
             
->>>>>>> [server] add uid and gid args to celery worker command
 
     def handle(self, *args, **options):
         self.stdout.write('Starting celery worker with autoreload...')
@@ -60,7 +46,3 @@ class Command(BaseCommand):
                 'gid': options.get('gid'),
             }
         autoreload.run_with_reloader(restart_celery, args=None, kwargs=kwargs)
-<<<<<<< HEAD
-=======
-
->>>>>>> [server] add uid and gid args to celery worker command

--- a/timeside/server/management/commands/timeside-celery-worker.py
+++ b/timeside/server/management/commands/timeside-celery-worker.py
@@ -13,8 +13,12 @@ def restart_celery(*args, **kwargs):
     kwargs = kwargs['kwargs']
     kill_worker_cmd = 'pkill -9 celery'
     subprocess.call(shlex.split(kill_worker_cmd))
+<<<<<<< HEAD
     start_worker_cmd = 'celery -A worker worker --loglevel=%s --logfile=%s --uid=%uid --gid=%gid' %
         (kwargs['loglevel'], kwargs['logfile'], kwargs['uid'], kwargs['gid'])
+=======
+    start_worker_cmd = 'celery -A worker worker --loglevel=%s --logfile=%s --uid=%s --gid=%s' % (kwargs['loglevel'], kwargs['logfile'], kwargs['uid'], kwargs['gid'])
+>>>>>>> [server] add uid and gid args to celery worker command
     subprocess.call(shlex.split(start_worker_cmd))
 
 
@@ -31,12 +35,21 @@ class Command(BaseCommand):
 
         parser.add_argument('-u', '--uid',
             dest='uid',
+<<<<<<< HEAD
             help='define the uid')
 
         parser.add_argument('-g', '--gid',
             dest='gid',
             help='define the gid')
 
+=======
+            help='define worker uid')
+
+        parser.add_argument('-g', '--gid',
+            dest='gid',
+            help='define worker gid')
+            
+>>>>>>> [server] add uid and gid args to celery worker command
 
     def handle(self, *args, **options):
         self.stdout.write('Starting celery worker with autoreload...')
@@ -47,3 +60,7 @@ class Command(BaseCommand):
                 'gid': options.get('gid'),
             }
         autoreload.run_with_reloader(restart_celery, args=None, kwargs=kwargs)
+<<<<<<< HEAD
+=======
+
+>>>>>>> [server] add uid and gid args to celery worker command


### PR DESCRIPTION
Add uid and gid options to the celery command.

Ownership of celery and app logs and of media are set to `www-data` in `app_base.sh` so that for both worker and app have access to them whichever one is up first.

Any Django admin command (`python3 $manage`) before app start is run with this `uid:gid` to avoid creation of `var/log/app/timeside_debug.log` file with the wrong rights.

It has been tested from scratch.